### PR TITLE
Remove square brackets

### DIFF
--- a/src/Filament/Resources/TicketResource/Pages/EditTicket.php
+++ b/src/Filament/Resources/TicketResource/Pages/EditTicket.php
@@ -24,7 +24,7 @@ class EditTicket extends EditRecord
     {
         $interacted = $this->record?->ticketable;
 
-        return __('Ticket') . ' [' . $interacted?->{$interacted?->model_name()} . ']';
+        return __('Ticket') . ($interacted ? ' [' . $interacted?->{$interacted?->model_name()} . ']' : '');
     }
 
     protected function afterFill()


### PR DESCRIPTION
This PR removes the square brackets when the ticket is not associated with a model. I thought it looks a bit strange when there were `[]` after the titles.